### PR TITLE
fix: update PluginDescriptor args

### DIFF
--- a/src/main/java/com/rohanbansal/ScapeGptPlugin.java
+++ b/src/main/java/com/rohanbansal/ScapeGptPlugin.java
@@ -18,7 +18,7 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 
 @Slf4j
-@PluginDescriptor(name = "ScapeGPT", loadWhenOutdated = true)
+@PluginDescriptor(name = "ScapeGPT")
 public class ScapeGptPlugin extends Plugin {
     private static final String HOST = "44.211.86.102";  // Server IP address that handles requests
     private static final String ENDPOINT = "api/v1/query";


### PR DESCRIPTION
```
> Task :compileJava FAILED
/tmp/pluginhub-package11082602222547477078/scapegpt/repo/src/main/java/com/rohanbansal/ScapeGptPlugin.java:21: error: cannot find symbol
@PluginDescriptor(name = "ScapeGPT", loadWhenOutdated = true)
                                     ^
  symbol:   method loadWhenOutdated()
  location: @interface PluginDescriptor
1 error
```